### PR TITLE
Fix timezones to be consistent with Linux

### DIFF
--- a/spec_creation/evaluation.spec.sample
+++ b/spec_creation/evaluation.spec.sample
@@ -5,7 +5,7 @@
     "region": {
         "osm_id": 2157162589,
         "name": "San Francisco Bay Area",
-        "timezone": "America/Los_angeles"
+        "timezone": "America/Los_Angeles"
     },
     "start_fmt_date": "2019-06-11",
     "end_fmt_date": "2019-06-22",

--- a/spec_creation/examples/calibration.only.json
+++ b/spec_creation/examples/calibration.only.json
@@ -5,7 +5,7 @@
     "region": {
         "osm_id": 2157162589,
         "name": "San Francisco Bay Area",
-        "timezone": "America/Los_angeles"
+        "timezone": "America/Los_Angeles"
     },
     "start_fmt_date": "2019-06-13",
     "end_fmt_date": "2019-06-20",


### PR DESCRIPTION
Also manually updated on the server

```
In [105]: edb.get_usercache_db().update_many({"metadata.key": "config/evaluation_spec"},
     ...:  {"$set": {"data.label.region.timezone": "America/Los_Angeles"}})
```