### PR TITLE
Visualizations for the San Jose and Los Altos trips

### DIFF
--- a/emeval/input/eval_view.py
+++ b/emeval/input/eval_view.py
@@ -123,6 +123,7 @@ class EvaluationView:
             print("Processing data for %s phones" % phoneOS)
             self.eval_eval_view_map[phoneOS] = {}
             all_eval_ranges = [m["evaluation_ranges"] for m in phone_map.values()]
+            # print("all_eval_ranges = %s" % ([r["trip_id"] for r in all_eval_ranges]))
             # all the lengths are equal - i.e. the set of lengths has one entr
             assert len(set([len(a) for a in all_eval_ranges])) == 1
             for ctuple in zip(*all_eval_ranges):
@@ -130,7 +131,8 @@ class EvaluationView:
                 assert len(common_names) == 1
                 common_name = list(common_names)[0]
                 # print(common_name)
-                self.eval_eval_view_map[phoneOS][common_name] = {}
+                if common_name not in self.eval_eval_view_map[phoneOS]:
+                    self.eval_eval_view_map[phoneOS][common_name] = {}
 
                 separate_roles = [r["eval_role"] for r in ctuple]
                 print(separate_roles)
@@ -143,8 +145,9 @@ class EvaluationView:
                     common_trip_ids = set([ctt["trip_id"] for ctt in ctriptuple])
                     assert(len(common_trip_ids)) == 1
                     common_trip_id = list(common_trip_ids)[0]
-                    print(common_trip_id)
-                    self.eval_eval_view_map[phoneOS][common_name][common_trip_id] = {}
+                    print("Common trip id = %s" % common_trip_id)
+                    if common_trip_id not in self.eval_eval_view_map[phoneOS][common_name]:
+                        self.eval_eval_view_map[phoneOS][common_name][common_trip_id] = {}
                     for cr, ctt in zip(separate_roles, ctriptuple):
                         self.eval_eval_view_map[phoneOS][common_name][common_trip_id][cr] = ctt
         print("android keys = %s" % self.eval_eval_view_map["android"].keys())

--- a/emeval/validate/phone_view.py
+++ b/emeval/validate/phone_view.py
@@ -139,7 +139,9 @@ def validate_evaluation_settings(phone_view):
                 print("%s -> %s" % (r["trip_id"], [c["data"]["accuracy"] for c in config_during_test_entries]))
                 # assert len(config_during_test_entries) == 1, "Out of band configuration? Found %d config changes" % len(config_during_test_entries)
                 config_during_test = config_during_test_entries[0]["data"]
-                expected_config = expected_config_map[phoneOS][r["trip_id"]]
+                trip_id_base = "_".join(r["trip_id"].split("_")[:-1])
+                print("Mapped %s -> %s" % (r["trip_id"], trip_id_base))
+                expected_config = expected_config_map[phoneOS][trip_id_base]
                 # print(config_during_test.keys(), expected_config.keys())
                 _validate_filter(phoneOS, config_during_test, expected_config)
                 _validate_accuracy(phoneOS, config_during_test, expected_config)

--- a/emeval/viz/eval_view.py
+++ b/emeval/viz/eval_view.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import re
 
 import folium
 import folium
@@ -17,12 +18,14 @@ def plot_separate_power_drain_multiple_runs(fig, ncols, eval_map, trip_id_patter
     all_handles = []
     all_labels = []
     for i, (curr_calibrate, curr_calibrate_trip_map) in enumerate(eval_map.items()): # high_accuracy_train_AO
+        # print(curr_calibrate_trip_map.keys())
         if trip_id_pattern not in curr_calibrate:
             print("curr_calibrate = %s, not matching pattern %s, skipping" % (curr_calibrate, trip_id_pattern))
             continue
         ax = fig.add_subplot(nRows, ncols, i+1, title=curr_calibrate)
         for curr_cal_run, cal_phone_map in curr_calibrate_trip_map.items():
-            # print("Handling data for run %s" % (curr_cal_run))
+            print("Handling data for run %s" % (curr_cal_run))
+            # print("Handling data for run %s, %s" % (curr_cal_run, cal_phone_map))
             for phone_label, phone_data_map in cal_phone_map.items():
                 # print("Extracting data for %s from map with keys %s" % (phone_label, phone_data_map.keys()))
                 battery_df = phone_data_map["battery_df"]
@@ -127,44 +130,69 @@ def get_map_list_single_run(eval_view, range_key, trip_id_pattern):
             map_list.append(curr_map)
     return map_list
 
-def get_map_list_eval_trips(eval_view, range_key, trip_id_pattern):
+# The compare pattern is a regular expression so that you can do
+# HAHFDC|HAMFDC. Others are basic strings, at least for now
+
+def get_map_list_eval_trips(eval_view, os_pattern, trip_id_pattern, compare_pattern):
+    compare_pattern_re = re.compile("("+compare_pattern + ")|accuracy_control")
+    print(compare_pattern_re)
     map_list = []
-    color_list = ['blue', 'red', 'purple', 'orange']
+    color_list = ['blue', 'red', 'purple', 'orange', "green", "magenta", "gray", "yellow"]
     for phoneOS, phone_map in eval_view.map("evaluation").items():
         print("Processing data for %s phones" % phoneOS)
+        if os_pattern not in phoneOS:
+            print("pattern %s not found in %s, skipping" % (os_pattern, phoneOS))
+            continue
+
         for curr_eval, curr_eval_trip_map in phone_map.items():
+            print("curr_eval = %s" % curr_eval)
             for curr_eval_trip_id, eval_trip_compare_map in curr_eval_trip_map.items():
+                if trip_id_pattern not in curr_eval_trip_id:
+                    print("pattern %s not found in %s, skipping" %
+                        (trip_id_pattern, curr_eval_trip_id))
+                    continue
+                print("curr_eval_trip_id = %s, creating new map" % curr_eval)
                 curr_map = folium.Map()
                 all_points = []
                 for i, (compare_id, compare_tr) in enumerate(eval_trip_compare_map.items()):
-                    if i == len(eval_trip_compare_map) - 1:
+                    # print(i, len(eval_trip_compare_map.items()))
+                    # print(compare_pattern_re.search(compare_id))
+                    if compare_pattern_re.search(compare_id) is None:
+                        print("compare_id = %s, not matching pattern %s, skipping" % (compare_id, compare_pattern))
+                        continue
+                    if "power_control" in compare_id:
                         print("Skipping the last item (power_control)")
                         continue
                     location_df = compare_tr["location_df"]
+                    print("Found %d locations for %s, %s, %s" %
+                        (len(location_df), curr_eval, curr_eval_trip_id, compare_id))
                     latlng_route_coords = list(zip(location_df.latitude, location_df.longitude))
                     all_points.extend(latlng_route_coords)
                     # print(latlng_route_coords[0:10])
                     if len(latlng_route_coords) > 0:
-                        print("Processing %s, %s, %s, found %d locations, adding to map" %
-                          (curr_eval, curr_eval_trip_id, compare_id, len(latlng_route_coords)))
+                        print("Processing %s, %s, %s, found %d locations, adding to map with color %s" %
+                          (curr_eval, curr_eval_trip_id, compare_id, len(latlng_route_coords), color_list[i]))
                         pl = folium.PolyLine(latlng_route_coords,
                             popup="%s" % (compare_id), color=color_list[i])
                         pl.add_to(curr_map)
                     else:
                         print("Processing %s, %s, %s, found %d locations, skipping" %
                           (curr_eval, curr_eval_trip_id, compare_id, len(latlng_route_coords)))
-                curr_bounds = ful.get_bounds(all_points)
-                print(curr_bounds)
-                top_lat = curr_bounds[0][0]
-                mid_lng = (curr_bounds[0][1] + curr_bounds[1][1])/2
-                print("for trip %s with %d points, midpoint = %s, %s, plotting at %s, %s" %
-                      (curr_eval_trip_id, len(all_points), top_lat,mid_lng, top_lat, mid_lng))
-                folium.map.Marker(
-                    [top_lat, mid_lng],
-                    icon=fof.DivIcon(
-                        icon_size=(200,36),
-                        html='<div style="font-size: 12pt; color: green;">%s: %s</div>' % (phoneOS, curr_eval_trip_id))
-                ).add_to(curr_map)
-                curr_map.fit_bounds(pl.get_bounds())
+
+                if len(all_points) > 0:
+                    curr_bounds = ful.get_bounds(all_points)
+                    print(curr_bounds)
+                    top_lat = curr_bounds[0][0]
+                    mid_lng = (curr_bounds[0][1] + curr_bounds[1][1])/2
+                    print("for trip %s with %d points, midpoint = %s, %s, plotting at %s, %s" %
+                          (curr_eval_trip_id, len(all_points), top_lat,mid_lng, top_lat, mid_lng))
+                    folium.map.Marker(
+                        [top_lat, mid_lng],
+                        icon=fof.DivIcon(
+                            icon_size=(200,36),
+                            html='<div style="font-size: 12pt; color: green;">%s: %s</div>' % (phoneOS, curr_eval_trip_id))
+                    ).add_to(curr_map)
+                    curr_map.fit_bounds(pl.get_bounds())
                 map_list.append(curr_map)
+    print("Returning %s" % map_list)
     return map_list

--- a/example_visualization_san_jose_round_trip.ipynb
+++ b/example_visualization_san_jose_round_trip.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook demonstrates the result of the first round of data collection, for the Mountain View library <-> Los Altos library round trip."
+    "This notebook demonstrates the result of the first round of data collection, for the Mountain View library <-> San Jose library round trip."
    ]
   },
   {
@@ -87,7 +87,7 @@
    "source": [
     "DATASTORE_URL = \"http://cardshark.cs.berkeley.edu\"\n",
     "AUTHOR_EMAIL = \"shankari@eecs.berkeley.edu\"\n",
-    "sdunp = eisd.SpecDetails(DATASTORE_URL, AUTHOR_EMAIL, \"unimodal_trip_car_bike_mtv_la\")"
+    "sdunp = eisd.SpecDetails(DATASTORE_URL, AUTHOR_EMAIL, \"car_scooter_brex_san_jose\")"
    ]
   },
   {

--- a/spec_creation/Validate_spec_before_upload.ipynb
+++ b/spec_creation/Validate_spec_before_upload.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spec_to_validate = json.load(open(\"car_scooter_brex_san_jose.filled.json\"))\n",
+    "spec_to_validate = json.load(open(\"train_bus_ebike_mtv_ucb.filled.json\"))\n",
     "sensing_configs = json.load(open(\"sensing_regimes.all.specs.json\"))"
    ]
   },
@@ -180,11 +180,11 @@
     "    get_marker(trip[\"end_loc\"], \"red\").add_to(curr_map)\n",
     "    # trips from relations won't have waypoints\n",
     "    if \"waypoint_coords\" in trip:\n",
-    "        for i, wpc in enumerate(trip[\"waypoint_coords\"]):\n",
+    "        for i, wpc in enumerate(trip[\"waypoint_coords\"][\"geometry\"][\"coordinates\"]):\n",
     "            folium.map.Marker(\n",
     "                lonlat_swap(wpc), popup=\"%d\" % i,\n",
     "                icon=fof.DivIcon(class_name='leaflet-div-icon')).add_to(curr_map)\n",
-    "    print(\"Found %d coordinates for the route\" % (len(trip[\"route_coords\"])))\n",
+    "    print(\"Found %d coordinates for the route\" % (len(trip[\"route_coords\"][\"geometry\"][\"coordinates\"])))\n",
     "    latlng_route_coords = [lonlat_swap(rc) for rc in trip[\"route_coords\"][\"geometry\"][\"coordinates\"]]\n",
     "    folium.PolyLine(latlng_route_coords,\n",
     "                    popup=\"%s: %s\" % (trip[\"mode\"], trip[\"name\"])).add_to(curr_map)\n",
@@ -211,7 +211,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "evaluation_trips = spec_to_validate[\"evaluation_trips\"]\n",

--- a/spec_creation/create_ground_truth_for_legs.ipynb
+++ b/spec_creation/create_ground_truth_for_legs.ipynb
@@ -126,7 +126,7 @@
     "    get_marker(trip[\"end_loc\"], \"red\").add_to(curr_map)\n",
     "    # trips from relations won't have waypoints\n",
     "    if \"waypoint_coords\" in trip:\n",
-    "        for i, wpc in enumerate(trip[\"waypoint_coords\"]):\n",
+    "        for i, wpc in enumerate(trip[\"waypoint_coords\"][\"geometry\"][\"coordinates\"]):\n",
     "            folium.map.Marker(\n",
     "                lonlat_swap(wpc), popup=\"%d\" % i,\n",
     "                icon=fof.DivIcon(class_name='leaflet-div-icon')).add_to(curr_map)\n",
@@ -213,6 +213,59 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "curr_leg_spec = \\\n",
+    "{\n",
+    "                    \"id\": \"inner_suburb_downtown_walk\",\n",
+    "                    \"name\": \"Caltrain from SF to Mountain View\",\n",
+    "                    \"mode\": \"WALKING\",\n",
+    "                    \"start_loc\": {\n",
+    "                      \"type\": \"Feature\",\n",
+    "                      \"properties\": {\n",
+    "                        \"name\": \"Mountain View Transit Center\"\n",
+    "                      },\n",
+    "                      \"geometry\": {\n",
+    "                        \"type\": \"Polygon\",\n",
+    "                        \"coordinates\": [\n",
+    "                          [\n",
+    "                            [ -122.07675218582153, 37.39485875725021 ],\n",
+    "                            [ -122.0769828557968, 37.39444961714526 ],\n",
+    "                            [ -122.07471370697021, 37.3936355921696 ],\n",
+    "                            [ -122.074493765831, 37.39398080802943 ],\n",
+    "                            [ -122.07675218582153, 37.39485875725021 ]\n",
+    "                          ]\n",
+    "                        ]\n",
+    "                      }\n",
+    "                    },\n",
+    "                    \"end_loc\": {\n",
+    "                      \"type\": \"Feature\",\n",
+    "                      \"properties\": {\n",
+    "                        \"name\": \"Mountain View Library\"\n",
+    "                      },\n",
+    "                      \"geometry\": {\n",
+    "                        \"type\": \"Polygon\",\n",
+    "                        \"coordinates\": [\n",
+    "                          [\n",
+    "                            [ -122.08355963230133, 37.39091642895306 ],\n",
+    "                            [ -122.08428382873535, 37.38975713188671 ],\n",
+    "                            [ -122.08383858203888, 37.389573859018185 ],\n",
+    "                            [ -122.08340406417847, 37.390196132517175 ],\n",
+    "                            [ -122.08311975002289, 37.39012793841312 ],\n",
+    "                            [ -122.08280861377716, 37.390656441096894 ],\n",
+    "                            [ -122.08355426788331, 37.39096757399895 ],\n",
+    "                            [ -122.08355963230133, 37.39091642895306 ]\n",
+    "                          ]\n",
+    "                        ]\n",
+    "                      }\n",
+    "                    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "importlib.reload(aes)"
    ]
   },
@@ -222,61 +275,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "curr_leg_spec = \\\n",
-    "{\n",
-    "            \"id\": \"freeway_driving_weekday\",\n",
-    "            \"name\": \"Mountain View Library to San Jose King Library\",\n",
-    "            \"mode\": \"CAR\",\n",
-    "            \"start_loc\": {\n",
-    "              \"type\": \"Feature\",\n",
-    "              \"properties\": {\n",
-    "                \"name\": \"Mountain View Library\"\n",
-    "              },\n",
-    "              \"geometry\": {\n",
-    "                \"type\": \"Polygon\",\n",
-    "                \"coordinates\": [\n",
-    "                  [\n",
-    "                    [ -122.08355963230133, 37.39091642895306 ],\n",
-    "                    [ -122.08428382873535, 37.38975713188671 ],\n",
-    "                    [ -122.08383858203888, 37.389573859018185 ],\n",
-    "                    [ -122.08340406417847, 37.390196132517175 ],\n",
-    "                    [ -122.08311975002289, 37.39012793841312 ],\n",
-    "                    [ -122.08280861377716, 37.390656441096894 ],\n",
-    "                    [ -122.08355426788331, 37.39096757399895 ],\n",
-    "                    [ -122.08355963230133, 37.39091642895306 ]\n",
-    "                  ]\n",
-    "                ]\n",
-    "              }\n",
-    "            },\n",
-    "            \"end_loc\": {\n",
-    "              \"type\": \"Feature\",\n",
-    "              \"properties\": {\n",
-    "                \"name\": \"San Jose King Library\"\n",
-    "              },\n",
-    "              \"geometry\": {\n",
-    "                \"type\": \"Polygon\",\n",
-    "                \"coordinates\": [\n",
-    "                  [\n",
-    "                    [ -121.88688397407532, 37.33674277401349 ],\n",
-    "                    [ -121.8852210044861, 37.33460162979272 ],\n",
-    "                    [ -121.88409447669984, 37.33517744150916 ],\n",
-    "                    [ -121.88620805740356, 37.33704560024162 ],\n",
-    "                    [ -121.88688397407532, 37.33674277401349 ]\n",
-    "                  ]\n",
-    "                ]\n",
-    "              }\n",
-    "            },\n",
-    "            \"polyline\": \"ayecF~nchVeB}@aFkCMGSKOIgCsAyAu@f@gBn@{BqCyA{Aw@MIDKd@aBTu@Lc@FSQKEA]Se@WgAi@GKCCEGGGGGKGy@g@IGIEYQCCSMYSy@c@wBkAQ@a@SKGs@_@u@c@A?UMc@[}@u@MKo@s@MQSYu@kA]g@[a@i@{@CEU]KMIOc@m@cAyACU_@k@]i@OYcBeCS[_@i@i@y@q@aAS[cA}AeEoFKMa@i@iBkBu@w@i@i@k@m@i@c@KG_@Wm@[o@W_Aa@_A]KC@Q@E?UAUCWG[GYK[GUKUKUMUMSMSk@w@IQIQCSESAU?S?UBUDcCvDaY~BgQ\\\\gC`@iCd@iCrB}Kl@oD^aC\\\\eCZ}BtBoOrJmt@p@}Ev@aG~CuUhEa\\\\\\\\mC`BcMhIan@|D}YJu@fDeWfAaHzCyPxFoZhBoJ~AyHzCaO`@mB~@yEjAmGn@gDdAqFxA_ItEiW|Iie@vCsOhC_NfDaQj@}CP_AnFkYtF{YrCkOjB}JfA{GrBqOpBkPhB{OzCiXFk@bBuNjCaUf@eEX_CZyBj@uDDYh@aBl@_EVkA~@oEh@eBZo@Xi@`AmAj@k@j@_@VMTI^M\\\\KzCu@pAa@r@S~@c@\\\\Op@c@d@_@XYf@i@b@g@j@{@NYf@{@jAyBnAaCrFoKr@oAt@mA|@qA`AmAfAoAdAcAtAiAxAgAlA{@vUyOlMyIvEaDnGkE|BwA~CkBzBgAxCsAjIsDl@Yl@[t@g@r@e@hB}AnB_Cd@u@`@s@d@{@b@_A`@eA`AcCdA_Cv@wAv@kAr@}@p@w@r@s@r@o@f@_@d@[`@Wh@[z@a@fBs@bC_A`Bu@`Ae@`@WdGqD^E|CmBj@YdD{AVKZI^Ef@A`@Dr@NRBf@FVBT?^EXGf@STKTI\\\\QTKdAu@bBoAPUHe@@w@Gy@Co@@]DYfA{@JInBqA^SRMNMDGL[N_@Zu@Te@HKh@m@rCgBt@e@PKSk@EMACsAsDqAmDEMEIcAkCIUKYiA}CCGi@{AEMGOUo@Yu@e@mAAGEIGQe@mAk@}AIUKUmAaDIUMYQe@Qe@\"\n",
-    "        }"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "aes.validate_and_fill_leg(curr_leg_spec)"
+    "curr_leg_spec = aes.validate_and_fill_leg(curr_leg_spec)"
    ]
   },
   {
@@ -291,7 +290,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "get_map_for_evaluation_trip(curr_leg_spec)"
@@ -301,8 +302,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Sat down in San Jose: 12:28pm"
+    "Sat down in San Jose: 12:28pm\n",
+    "Got up from San Jose: 3:47pm"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/spec_creation/final_sfbayarea/car_scooter_brex_san_jose.json
+++ b/spec_creation/final_sfbayarea/car_scooter_brex_san_jose.json
@@ -118,7 +118,7 @@
                     ]
                   }
                 },
-                "polyline": "kd{bF~w|fVTn@QRxHnSaEpCkErC{GzEeLtHnCzGsCnBOHwBzBq@|@e@t@qEvISj@U~@KdA?x@B`@J|@Nv@DTvAnE`@`BxAxHJp@RnBRdEAzCI|BK`B]hC{@vGSz@o@dBU^e@n@qAxAB`@h@~@d@r@fBzClBnCJ~@AP_@t@gBrBnOtVzDbGZ_@"
+                "polyline": "kd{bF~w|fVTn@QRxHnSaEpCkErC{GzEeLtHnCzGjA`DkAaDsCnBOHwBzBq@|@e@t@qEvISj@U~@KdA?x@B`@J|@Nv@DTvAnE`@`BxAxHJp@RnBRdEAzCI|BK`B]hC{@vGSz@o@dBU^e@n@qAxAB`@h@~@d@r@fBzClBnCJ~@AP_@t@gBrBnOtVzDbGZ_@"
             },{
                 "id": "city_bus_rapid_transit",
                 "name": "#522 Rapid from San Jose to Mountain View",

--- a/spec_creation/final_sfbayarea/train_bus_ebike_mtv_ucb.json
+++ b/spec_creation/final_sfbayarea/train_bus_ebike_mtv_ucb.json
@@ -1,0 +1,671 @@
+{
+    "fmt_version": 1,
+    "id": "train_bus_ebike_mtv_ucb",
+    "name": "Multimodal multi-train, multi-bus, ebike trip to UC Berkeley",
+    "region": {
+        "osm_id": 2157162589,
+        "name": "San Francisco Bay Area",
+        "timezone": "America/Los_Angeles"
+    },
+    "start_fmt_date": "2019-07-16",
+    "end_fmt_date": "2019-07-18",
+    "phones": {
+        "android": {
+          "ucb-sdb-android-1": "accuracy_control",
+          "ucb-sdb-android-2": "evaluation_0",
+          "ucb-sdb-android-3": "evaluation_1",
+          "ucb-sdb-android-4": "power_control"
+        },
+        "ios": {
+          "ucb-sdb-ios-1": "accuracy_control",
+          "ucb-sdb-ios-2": "evaluation_0",
+          "ucb-sdb-ios-3": "evaluation_1",
+          "ucb-sdb-ios-4": "power_control"
+        }
+    },
+    "calibration_tests": [
+    ],
+    "sensing_settings": [{
+        "android": ["HAHFDC", "HAMFDC"],
+        "ios": ["HAHFDC", "MAHFDC"]
+    }],
+    "evaluation_trips": [
+        {
+            "id": "mtv_to_berkeley_sf_bart",
+            "name": "To UCB on Caltrain and BART through SF",
+            "legs":[
+                {
+                    "id": "walk_to_caltrain",
+                    "name": "Mountain View Library to Mountain View Transit Center",
+                    "mode": "WALKING",
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Library"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.08355963230133, 37.39091642895306 ],
+                            [ -122.08428382873535, 37.38975713188671 ],
+                            [ -122.08383858203888, 37.389573859018185 ],
+                            [ -122.08340406417847, 37.390196132517175 ],
+                            [ -122.08311975002289, 37.39012793841312 ],
+                            [ -122.08280861377716, 37.390656441096894 ],
+                            [ -122.08355426788331, 37.39096757399895 ],
+                            [ -122.08355963230133, 37.39091642895306 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Transit Center"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.07675218582153, 37.39485875725021 ],
+                            [ -122.0769828557968, 37.39444961714526 ],
+                            [ -122.07471370697021, 37.3936355921696 ],
+                            [ -122.074493765831, 37.39398080802943 ],
+                            [ -122.07675218582153, 37.39485875725021 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "waypoint_coords": {
+                      "type": "Feature",
+                      "geometry": {
+                        "type": "LineString",
+                        "coordinates": []
+                      }
+                    }
+                },
+                {
+                    "id": "commuter_rail_aboveground",
+                    "name": "Caltrain from Mountain View to Millbrae",
+                    "mode": "TRAIN",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Transit Center"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.07675218582153, 37.39485875725021 ],
+                            [ -122.07689702510832, 37.39466697310411 ],
+                            [ -122.07467079162598, 37.39375918815397 ],
+                            [ -122.074493765831, 37.39398080802943 ],
+                            [ -122.07675218582153, 37.39485875725021 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "osm_id": 77411120,
+                        "name": "Millbrae Intermodal Terminal"
+                      },
+                      "geometry": {
+                        "type": "Polygon"
+                      }
+                    },
+                    "relation": {
+                        "relation_id": 9605484,
+                        "start_node": 6138188701,
+                        "end_node": 1342778583
+                    }
+                },{
+                    "id": "subway_underground",
+                    "name": "BART from Millbrae to Berkeley",
+                    "mode": "SUBWAY",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "osm_id": 77411120,
+                        "name": "Millbrae Intermodal Terminal"
+                      },
+                      "geometry": {
+                        "type": "Polygon"
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Downtown Berkeley BART"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.26870179176329, 37.871262515520044 ],
+                            [ -122.26839065551758, 37.86921292650199 ],
+                            [ -122.2675323486328, 37.869280682422094 ],
+                            [ -122.26801514625548, 37.87133026955532 ],
+                            [ -122.26870179176329, 37.871262515520044 ]
+                          ]
+                        ]    
+                      }
+                    },
+                    "relation": {
+                        "relation_id": 2851613,
+                        "start_node": 5317898424,
+                        "end_node": 2239764355
+                    }
+                },{
+                    "id": "walk_to_bus",
+                    "name": "Walk from BART station to shuttle bus stop",
+                    "mode": "WALKING",
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Downtown Berkeley BART"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.26870179176329, 37.871262515520044 ],
+                            [ -122.26839065551758, 37.86921292650199 ],
+                            [ -122.2675323486328, 37.869280682422094 ],
+                            [ -122.26801514625548, 37.87133026955532 ],
+                            [ -122.26870179176329, 37.871262515520044 ]
+                          ]
+                        ]    
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Addison and Shattuck"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.26778447628023, 37.871211699952674 ],
+                            [ -122.26777911186217, 37.87095762159011 ],
+                            [ -122.26760745048522, 37.870983029465805 ],
+                            [ -122.26759672164917, 37.87124557700147 ],
+                            [ -122.26778447628023, 37.871211699952674 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "waypoint_coords": {
+                      "type": "Feature",
+                      "geometry": {
+                        "type": "LineString",
+                        "coordinates": []
+                      }
+                    }
+                },{
+                    "id": "city_bus_short",
+                    "name": "shuttle bus from downtown to cory",
+                    "mode": "BUS",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Addison and Shattuck"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.26778447628023, 37.871211699952674 ],
+                            [ -122.26777911186217, 37.87095762159011 ],
+                            [ -122.26760745048522, 37.870983029465805 ],
+                            [ -122.26759672164917, 37.87124557700147 ],
+                            [ -122.26778447628023, 37.871211699952674 ]
+                          ]
+                        ]    
+                      }
+                    }, "end_loc": {
+                        "type": "Feature",
+                        "properties": {
+                            "name": "Soda/Cory Hall"
+                        },
+                        "geometry": {
+                          "type": "Polygon",
+                          "coordinates": [
+                            [
+                              [ -122.25856840610504, 37.8757383825689 ],
+                              [ -122.25853621959686, 37.87519638097388 ],
+                              [ -122.25781202316284, 37.875259896992084 ],
+                              [ -122.25830018520354, 37.875759554425294 ],
+                              [ -122.25856840610504, 37.8757383825689 ]
+                            ]
+                          ]
+                        }
+                    },
+                    "relation": {
+                        "relation_id": 9709380,
+                        "start_node": 6410508153,
+                        "end_node": 6561896571
+                    }
+                }
+            ]
+        },
+        {
+            "id": "walk_urban_university",
+            "name": "Soda to HFA-B with some detours",
+            "mode": "WALKING",
+            "start_loc": {
+                "type": "Feature",
+                "properties": {
+                    "name": "Soda/Cory Hall"
+                },
+                "geometry": {
+                  "type": "Polygon",
+                  "coordinates": [
+                    [
+                      [ -122.25856840610504, 37.8757383825689 ],
+                      [ -122.25853621959686, 37.87519638097388 ],
+                      [ -122.25781202316284, 37.875259896992084 ],
+                      [ -122.25830018520354, 37.875759554425294 ],
+                      [ -122.25856840610504, 37.8757383825689 ]
+                    ]
+                  ]
+                }
+            }, "end_loc": {
+              "type": "Feature",
+              "properties": {
+                "name": "HFA-B"
+              },
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [ -122.25775301456453, 37.86966180831176 ],
+                    [ -122.25761353969574, 37.86925527395936 ],
+                    [ -122.25752770900726, 37.8692722129355 ],
+                    [ -122.25767254829408, 37.86967027775357 ],
+                    [ -122.25775301456453, 37.86966180831176 ]
+                  ]
+                ]
+              }
+            },
+            "waypoint_coords": {
+              "type": "Feature",
+              "properties": {},
+              "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                  [ -122.25815534591676, 37.875310709767206 ],
+                  [ -122.25729167461395, 37.87324852982449 ],
+                  [ -122.25858449935912, 37.872757324446724 ],
+                  [ -122.25830554962157, 37.872033213994904 ],
+                  [ -122.25767254829408, 37.870411350143584 ],
+                  [ -122.25762426853179, 37.869721094384055 ],
+                  [ -122.25762426853179, 37.869467010881124 ]
+                ]
+              }
+            }
+        },{
+            "id": "berkeley_to_mtv_SF_express_bus",
+            "name": "Multimodal trip through SF by bus and muni",
+            "legs":[
+                { 
+                    "id": "walk to the bikeshare location",
+                    "name": "HFA-B to bikeshare location",
+                    "mode": "WALKING",
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "HFA-B"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.25775301456453, 37.86966180831176 ],
+                            [ -122.25761353969574, 37.86925527395936 ],
+                            [ -122.25752770900726, 37.8692722129355 ],
+                            [ -122.25767254829408, 37.86967027775357 ],
+                            [ -122.25775301456453, 37.86966180831176 ]
+                          ]
+                        ]
+                      }
+                    }, "end_loc": {
+                        "type": "Feature",
+                        "properties": {
+                            "name": "Wurster bikeshare station"
+                        },
+                        "geometry": {
+                          "type": "Polygon",
+                          "coordinates": [
+                            [
+                              [ -122.25501716136932, 37.87000058522528 ],
+                              [ -122.2549045085907, 37.8692213959954 ],
+                              [ -122.2539871931076, 37.86933573406131 ],
+                              [ -122.25415349006651, 37.87011492208202 ],
+                              [ -122.25501716136932, 37.87000058522528 ]
+                              ]
+                          ]
+                        }
+                    },
+                    "waypoint_coords": {
+                      "type": "Feature",
+                      "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                          [ -122.2573506832123, 37.86900118885007 ],
+                          [ -122.25430905818939, 37.86940772460436 ]
+                        ]
+                      }
+                    }
+                },{
+                    "id": "ebike_bikeshare_urban_long",
+                    "name": "Wurster bikeshare station to 40th San Pablo",
+                    "mode": "BICYCLING",
+                    "start_loc": {
+                        "type": "Feature",
+                        "properties": {
+                            "name": "Wurster bikeshare station"
+                        },
+                        "geometry": {
+                          "type": "Polygon",
+                          "coordinates": [
+                            [
+                              [ -122.25501716136932, 37.87000058522528 ],
+                              [ -122.2549045085907, 37.8692213959954 ],
+                              [ -122.2539871931076, 37.86933573406131 ],
+                              [ -122.25415349006651, 37.87011492208202 ],
+                              [ -122.25501716136932, 37.87000058522528 ]
+                              ]
+                          ]
+                        }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "40th and San Pablo"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.27970957756044, 37.8312979574766 ],
+                            [ -122.27974176406859, 37.831124243341165 ],
+                            [ -122.27826654911041, 37.831115769470415 ],
+                            [ -122.27857768535613, 37.83149709268966 ],
+                            [ -122.27970957756044, 37.8312979574766 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "waypoint_coords": {
+                      "type": "Feature",
+                      "properties": {},
+                      "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                          [
+                            -122.27141618728638,
+                            37.848997707091975
+                          ],
+                          [
+                            -122.27179169654846,
+                            37.84719742398725
+                          ],
+                          [
+                            -122.27291822433472,
+                            37.846312092173754
+                          ]
+                        ]
+                      }
+                    }
+                },{ 
+                    "id": "express_bus",
+                    "name": "Express bus (#F/#C) to the Transbay Terminal",
+                    "mode": "BUS",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "40th and San Pablo"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.27970957756044, 37.8312979574766 ],
+                            [ -122.27974176406859, 37.831124243341165 ],
+                            [ -122.27826654911041, 37.831115769470415 ],
+                            [ -122.27857768535613, 37.83149709268966 ],
+                            [ -122.27970957756044, 37.8312979574766 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Transbay Terminal"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.3944705724716, 37.78995941695691 ],
+                            [ -122.39273786544798, 37.78854771727019 ],
+                            [ -122.39168107509613, 37.78940406684465 ],
+                            [ -122.39341914653778, 37.79076487916853 ],
+                            [ -122.3944705724716, 37.78995941695691 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "relation": {
+                        "relation_id": 2718359,
+                        "start_node": 6410561636,
+                        "end_node": 2504237931
+                    }
+                },{ 
+                    "id": "walk_downtown_urban_canyon",
+                    "name": "Transbay Terminal to Embarcadero station",
+                    "mode": "WALKING",
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Transbay Terminal"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.3944705724716, 37.78995941695691 ],
+                            [ -122.39273786544798, 37.78854771727019 ],
+                            [ -122.39168107509613, 37.78940406684465 ],
+                            [ -122.39341914653778, 37.79076487916853 ],
+                            [ -122.3944705724716, 37.78995941695691 ]
+                          ]
+                        ]
+                      }
+                    }, "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Embarcadero Station",
+                        "osm_id": 551273355
+                      },
+                      "geometry": {
+                        "type": "Polygon"
+                      }
+                    }
+                },{ 
+                    "id": "light_rail_below_above_ground",
+                    "name": "Muni Metro Line N",
+                    "mode": "LIGHT_RAIL",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Embarcadero Station",
+                        "osm_id": 551273355
+                      },
+                      "geometry": {
+                        "type": "Polygon"
+                      }
+                    }, "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "4th and King"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.3953503370285, 37.77651114049218 ],
+                            [ -122.39456176757811, 37.77589632788213 ],
+                            [ -122.39346742630003, 37.77597264972546 ],
+                            [ -122.39371955394746, 37.77617617425586 ],
+                            [ -122.39412724971771, 37.77646873978666 ],
+                            [ -122.3953503370285, 37.77651114049218 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "relation": {
+                      "relation_id": 63223,
+                      "start_node": 5323877769,
+                      "end_node": 1723633815
+                    }
+                }, {
+                    "id": "commuter_rail_with_tunnels",
+                    "name": "Caltrain from SF to Mountain View",
+                    "mode": "TRAIN",
+                    "multiple_occupancy": true,
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "4th and King"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.3953503370285, 37.77651114049218 ],
+                            [ -122.39456176757811, 37.77589632788213 ],
+                            [ -122.39346742630003, 37.77597264972546 ],
+                            [ -122.39371955394746, 37.77617617425586 ],
+                            [ -122.39412724971771, 37.77646873978666 ],
+                            [ -122.3953503370285, 37.77651114049218 ]
+                          ]
+                        ]
+                      }
+                    }, "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Transit Center"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.07675218582153, 37.39485875725021 ],
+                            [ -122.0769828557968, 37.39444961714526 ],
+                            [ -122.07471370697021, 37.3936355921696 ],
+                            [ -122.074493765831, 37.39398080802943 ],
+                            [ -122.07675218582153, 37.39485875725021 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "relation": {
+                      "relation_id": 9605701,
+                      "start_node": 6138188689,
+                      "end_node": 6138188702
+                    }
+                },{
+                    "id": "inner_suburb_downtown_walk",
+                    "name": "Mountain View train station to library",
+                    "mode": "WALKING",
+                    "start_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Transit Center"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.07675218582153, 37.39485875725021 ],
+                            [ -122.0769828557968, 37.39444961714526 ],
+                            [ -122.07471370697021, 37.3936355921696 ],
+                            [ -122.074493765831, 37.39398080802943 ],
+                            [ -122.07675218582153, 37.39485875725021 ]
+                          ]
+                        ]
+                      }
+                    },
+                    "end_loc": {
+                      "type": "Feature",
+                      "properties": {
+                        "name": "Mountain View Library"
+                      },
+                      "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                          [
+                            [ -122.08355963230133, 37.39091642895306 ],
+                            [ -122.08428382873535, 37.38975713188671 ],
+                            [ -122.08383858203888, 37.389573859018185 ],
+                            [ -122.08340406417847, 37.390196132517175 ],
+                            [ -122.08311975002289, 37.39012793841312 ],
+                            [ -122.08280861377716, 37.390656441096894 ],
+                            [ -122.08355426788331, 37.39096757399895 ],
+                            [ -122.08355963230133, 37.39091642895306 ]
+                          ]
+                        ]
+                      }
+                    }
+                }
+            ]
+        }
+    ],
+    "setup_notes": {
+        "ios": [
+            "Initial iOS versions: ucb.sdb.ios.1: 9.3; ucb.sdb.ios.2: 11.2.1; ucb.sdb.ios.3: 9.3; ucb.sdb.ios.4: 10.3.2",
+            "iOS does not support incremental updates, so will need to update everything to the most recent iOS 12",
+            "update to 12.3.1",
+            "Erase all data and settings",
+            "English, United States",
+            "Set up manually",
+            "Connect to WiFi",
+            "Disabled: Touch ID, Automatic updates, Wallet, iCloud Keychain, Siri, Screen Time, Analytics",
+            "Enabled: Location services",
+            "Sign in with Apple ID",
+            "Turn off updates from the app store",
+            "Login to gmail through the mail app",
+            "phone #2 turned out to have 50% battery health. Replaced battery",
+            "turned on _do not disturb_ for consistency with android"
+        ],
+        "android": [
+            "factory data reset (still at version 6.0.1)",
+            "English, United States",
+            "Connect to WiFi",
+            "Sign in with google account",
+            "Don't back up data, enable google location service, improve location accuracy, don't send diagnostic data",
+            "Not setting up: payment info, other email",
+            "Don't restore; set up password",
+            "Don't enable Google Now",
+            "Don't accept update to 7",
+            "If prompted, add number",
+            "Turn off app auto-updates; 35 apps can be updated.; Update only the _Android System Webview_ manually",
+            "phone #3 is persistently stuck at an older version of google play services, although I follow the same procedure. and the older version is too old for the app.  So one-time update of all 35 apps.",
+            "even after the update, phone #3 has a different UI than the others. A/B testing?",
+            "got phone call on android 4, which turned on the screen and got the phone out of doze mode, turned on _do not disturb_",
+            "installed custom apk with native changes to better support reading battery level at the start and end of range. Installed OI File Manager + allowed installing apps from unknown sources. Retained the app, since it was consistent across all phones, but reverted settings changes before further testing. Had to give Chrome storage permission, and while reverting that, discovered that it also had location permission!! but I didn't change it because it was the default. I am fairly sure I don't recall being asked for location permissions from Chrome, but yeah right, it was already pre-installed, wasn't it."
+        ]
+    }
+}


### PR DESCRIPTION
+ bunch of changes to support them
+ bunch of changes to improve spec creation

@hariv the Los Altos trip should now work for android as well
@jf87 the visualizations should show you the data we currently have for these trips
The ground truth is in the associated specs under the `spec_creation` directory, or you can retrieve it from the server like the current modules do.

Couple of things to note:
- @jf87 I haven't had too much time to collect data, so I am focusing on high v/s medium frequency on android but high v/s medium accuracy on iOS. This is because the frequency does not make a difference in the power drain on iOS. So although e-mission uses a distance filter on iOS currently, it doesn't need to, and I plan to change the defaults after the current set of papers is done.
- @hariv, @jf87 There are modules for the phone view and the eval view; both are described in detail in the appropriate module. The more I work with this, the more I feel like I should use xarray since most of the work that the modules do relates to munging/moving around the data in different ways.
- @jf87 the downloaded data is in the same format as the files in "Download JSON dump" (it uses the same timeseries interface) so you should be able to download the raw data and load it onto your own server to run your scripts.

@hariv, @jf87 I will try to make a change tonight to display the ground truth in the maps, which should also give you an example of how to access the ground truth and the sensed data at the same time. But after that, I need to move on to other analysis...

I will probably also re-collect high v/s medium frequency for iOS but not before Aug 1st.