### PR TITLE
Restoring scipy since we now need it for the calibration interpolations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - pip=9.0.*
 - python=3.6.*
 - requests=2.22.*
+- scipy=1.1.*
 - shapely=1.6.*
 - pip:
     - osmapi==1.2.*


### PR DESCRIPTION
Thanks to @deculler for reporting this.
I thought that shapely installed scipy by default, so I removed it as part of 1cddf5c5c3ad2d681b85daf2d99e2a43b8b14dd8

However, this is apparently not true, at least on linux.
Everything works fine on OSX.
This may also be related to the switch to conda 4.7 on linux (and by extension repo2docker)
https://github.com/jupyterhub/binder/issues/166

Anyway, fixed by restoring the value