### PR TITLE
Support running analyses on the public data

### DIFF
--- a/bin/import_public_data.py
+++ b/bin/import_public_data.py
@@ -1,0 +1,49 @@
+import argparse
+
+import emeval.input.phone_view as eipv
+import emeval.input.spec_details as eisd
+import emeval.input.server_stub as eiss
+
+def load_from_spec_id(datastore_url, email, spec_id):
+    sd = eisd.SpecDetails(datastore_url, email, spec_id)
+    pv = eipv.PhoneView(sd)
+    return pv
+
+def save_to_db(db_url, phone_view):
+    sd = phone_view.spec_details
+    for phone_os, phone_map in pv.map().items():
+        print(15 * "=*")
+        print(phone_os, phone_map.keys())
+        for phone_label, phone_detail_map in phone_map.items():
+            print(4 * ' ', 15 * "-*")
+            print(4 * ' ', phone_label, phone_detail_map.keys())
+            phone_uuid = eiss.register_label(db_url, phone_label)
+            print("mapped %s -> %s" % (phone_label, phone_uuid))
+            # this spec does not have any calibration ranges, but evaluation ranges are actually cooler
+            for r in phone_detail_map["evaluation_ranges"]:
+                print(8 * ' ', 30 * "=")
+                print(8 * ' ',r.keys())
+                print(8 * ' ',r["trip_id"], r["eval_common_trip_id"], r["eval_role"], len(r["evaluation_trip_ranges"]))
+                all_entries = r["location_entries"]  + r["filtered_location_entries"] + r["motion_activity_entries"] + r["transition_entries"]
+                print("Combining %d locations, %d background locations, %d motion activity, %d transitions -> %d" %
+                    (len(r["location_entries"]), len(r["background_location_entries"]), len(r["motion_activity_entries"]), len(r["transition_entries"]), len(all_entries)))
+                eiss.post_entries(db_url, phone_label, all_entries)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("datastore_url",
+        help="host and port of the public datastore to download data from")
+    parser.add_argument("experiment_email",
+        help="the email of the experimenter, used to retrieve the specs from the public datastore")
+    parser.add_argument("spec_list", metavar='S', type=str, nargs='+',
+        help="the list of timeline specs that we should load the data from")
+    parser.add_argument("--db_url", default="http://localhost:8080",
+        help="database to store the entries to")
+
+    args = parser.parse_args()
+
+    pv_list = [load_from_spec_id(args.datastore_url, args.experiment_email, sid)
+        for sid in args.spec_list]
+    for pv in pv_list:
+        print("Copying data for spec %s" % pv.spec_details.CURR_SPEC_ID)
+        save_to_db(args.db_url, pv)

--- a/emeval/input/server_stub.py
+++ b/emeval/input/server_stub.py
@@ -1,0 +1,43 @@
+import requests
+import arrow
+import copy
+
+def register_label(server_url, phone_label):
+    """
+    Register the phone label on the specified URL. Used to create the phone
+    account on the dest server so that we can upload data to it
+    """
+    post_msg = {
+        "user": phone_label,
+    }
+    print("About to retrieve messages using %s" % post_msg)
+    response = requests.post(server_url+"/profile/create", json=post_msg)
+    print("response = %s" % response)
+    response.raise_for_status()
+    local_uuid = response.json()["uuid"]
+    print("Found local uuid %s" % local_uuid)
+    return local_uuid
+
+def post_entries(server_url, phone_label, entry_list):
+    """
+    Post the entries for the specified user. The uuid in the entry_list could
+    be different from the uuid on the server, since it has been retrieved from
+    a different server. So we rewrite the uuid before posting.
+    """
+
+    stripped_entries = [_strip_id_user(e) for e in entry_list]
+
+    post_msg = {
+        "user": phone_label,
+        "phone_to_server": stripped_entries
+    }
+    print("About to post %d messages (%s)..." % (len(stripped_entries), stripped_entries[0]))
+    response = requests.post(server_url+"/usercache/put", json=post_msg)
+    print("response = %s" % response)
+    response.raise_for_status()
+
+def _strip_id_user(e):
+    ce = copy.copy(e)
+    del ce["_id"]
+    del ce["user_id"]
+    return ce


### PR DESCRIPTION
Done so far:
- download data and store it to an temporary server (default `http://localhost:8080`). This allows us to delete and re-run analyses with multiple algorithms

USAGE:

Download the data (from this repo)

```
(emissioneval) e-mission-eval-public-data $ PYTHONPATH=. python bin/import_public_data.py http://cardshark.cs.berkeley.edu shankari@eecs.berkeley.edu car_scooter_brex_san_jose
```

Run the pipeline (from the server repo)

```
(emission) e-mission-server $ ./e-mission-py.bash bin/debug/intake_single_user.py -e ucb-sdb-ios-3
```

Next step:
- store the section ground truth as `mode_confirm` objects

Still need to figure out:
- how to store the trip ground truth? (`purpose_confirm`? `destination_confirm`?)
    - what about the trajectory?
- we are accessing the local server strictly through its public API, since we are outside the e-mission-server repository. This means that we can't:
   - load entries that have already passed through the pipeline once
   - delete entries (e.g. delete all the entries related to a particular spec once all the experiments are done)
   - run the pipeline automatically
   - reset the pipeline
   - ensure that the uuids on the local server are the same as the public datastore. Instead we re-register the phone labels and get new uuids and then change the `user_id` fields of the copied data.

None of these are showstoppers right now IMHO, so I am going to stick with this architecture. However, I just want to document the limitations. If any of them do become super important (e.g. loading entries that have passed through the pipeline), we can potentially address them by
1. adding new API methods, or 
1. splitting the monolithic server up into microservices and then including only the DB microservice code